### PR TITLE
A few improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ function inlineImports(base_path, file_path, options) {
 					fancyLog.info(PLUGIN_NAME + ': this unnamed import points to the file ', relativeFileName(base_path, importFilePath(importation)));
                 }
 
-                const file_sub_content = inlineImports(base_path, './example/' + importFilePath(importation), options );
+                const file_sub_content = inlineImports(base_path, importFilePath(importation), options );
 
                 content = content.substring(0, (importation.start + decay)) + file_sub_content + content.substring(importation.end + decay);
 

--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ function inlineImports(base_path, file_path, options) {
 					fancyLog.info(PLUGIN_NAME + ': this unnamed import points to the file ', relativeFileName(base_path, importFilePath(importation)));
                 }
 
-                const file_sub_content = inlineImports(base_path, importFilePath(importation), options );
+                const file_sub_content = inlineImports(base_path, base_path + path.sep + importFilePath(importation), options );
 
                 content = content.substring(0, (importation.start + decay)) + file_sub_content + content.substring(importation.end + decay);
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const through = require('through2');
 const pluginError = require('plugin-error');
 const typeOf = require('type-of');
 const fancyLog = require('fancy-log');
-const babylon = require('babylon');
+const babylon = require('@babel/parser');
 
 const fs = require('fs');
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gulp-cli": "2.*"
   },
   "dependencies": {
-    "babylon": "^6.18.0",
+    "@babel/parser": "^7.1.2",
     "fancy-log": "^1.3.2",
     "npm": "^6.0.0",
     "plugin-error": "1.*",


### PR DESCRIPTION
Hey!

I had back then suggested a new feature and I ended up doing some quick fix for my setup, but never actually tested if it was working generically. This PR aims to solves 3 problems I had dealt with:

- a requirement to `example` folder was hardcoded into the module, I positive this was a mistake
- fixed `allowImportExportEverywhere` so that it parses through the whole object searching for import declarations instead of just looking at the header of the file. The issue was that the code was not sifting through the whole object.
- relative paths were broken, it was always required to have the import be resolved having the base path of where gulp was running and not where the current parsed file was.

I also tested on latested `@babel/parser` since it has moved there, and it's working correctly.

I'm sorry for the delay but things can get quite busy, and I had to apply a quickfix to solve those issues.